### PR TITLE
Fix saving mcp inverted via webUI

### DIFF
--- a/frontend/src/components/UISettings/UISettings.tsx
+++ b/frontend/src/components/UISettings/UISettings.tsx
@@ -869,7 +869,7 @@ export default function UISettings() {
               if (isNaN(addr)) {
                 addr = entry.id === 'mcp_left' ? 0x20 : 0x21;
               }
-              return { id: entry.id, address: addr };
+              return { id: entry.id, address: addr, inverted: entry.inverted };
             }
             return entry;
           })


### PR DESCRIPTION
Fixes a WebUI bug that a change of inverted value is not taken into account. 

How to reproduce?
- Go to webUI
- Go to settings
- Open webconsole tools to look for api requests
- Change inverted to true and submit
- See the value is not sent.